### PR TITLE
[Feat] 로그인/회원가입 기능 구현

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -21,3 +21,11 @@ a{
     color: $main-color;
     text-decoration: none;
 }
+input{
+    border: none;
+    font-size: 16px;
+    border-radius: 10px;
+    background: $light-gray-color;
+    color: $dark-gray-color;
+    padding: 10px 15px;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,29 +1,36 @@
+"use client";
+
+import { FormEvent, use } from "react";
+import { useRouter } from "next/navigation";
 import styles from "./page.module.scss";
+import { login } from "@/lib/firebase/authAPI";
 
 export default function LoginPage() {
-  return (
-    
-  <div className={styles.login_page}>
-    <h1>
-      Rainit
-    </h1>
-    <div>
-      <div className={styles.auth_title}>
-          로그인
-      </div>
-      <div>
-          <input type="text" placeholder="아이디"/>
-      </div>
-      <div>
-          <input type="password" placeholder="비밀번호"/>
-      </div>
-      
-    </div>
-    <div className={styles.login_button}>
-      
-      로그인
-    </div>
-  </div>
+  const router = useRouter();
 
+  const handleLogin = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+    login(String(data.email), String(data.password), () =>
+      router.push("/home")
+    );
+  };
+
+  return (
+    <form className={styles.login_page} onSubmit={(e) => handleLogin(e)}>
+      <h1>Rainit</h1>
+      <div>
+        <input type="email" name="email" placeholder="이메일을 입력하세요" />
+        <input
+          type="password"
+          name="password"
+          placeholder="비밀번호를 입력하세요"
+        />
+      </div>
+      <button type="submit" className={styles.login_button}>
+        로그인
+      </button>
+    </form>
   );
 }

--- a/src/app/signup/page.module.scss
+++ b/src/app/signup/page.module.scss
@@ -1,36 +1,23 @@
-.login_page {
-    width: 100%;
+@import '../../lib/styles/_palette.scss';
+
+.main {
     height: 100vh;
+    padding: 100px 50px;
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: space-between;
+}
+
+.inputs{
+  margin-top: 50px;
+  text-align: center;
+  input{
+    margin: 5px;
   }
-  
-  .auth_title{
-  
-  }
-  
-  .login_page h1 {
-    margin-top: 20px;
-    margin-bottom: 20px;
-    color: #4BBD5D;
-  }
-  
-  .login_space{
-  
-  }
-  
-  .login_button{
-    display: flex;
-    bottom: 60px;
-    width: 80%;
-    height: 50px;
-    /* fill: #4BBD5D; */
-    /* font: ; */
-    color: #fff;
-    background: #4BBD5D;
-    border-radius: 12px;
-    justify-content: center;
-    align-items: center;
-    position: absolute;
-  }
+}
+
+.button{
+  background-color: $light-gray-color;
+  width: 100%;
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,29 +1,45 @@
+"use client";
+
+import { FormEvent } from "react";
 import styles from "./page.module.scss";
+import { createUserWithEmailAndPassword } from "firebase/auth";
+import { auth, db } from "../../lib/firebase";
+import { doc, setDoc } from "firebase/firestore";
 
 export default function LoginPage() {
-  return (
-    
-  <div className={styles.login_page}>
-    <h1>
-      Rainit
-    </h1>
-    <div>
-      <div className={styles.auth_title}>
-          로그인
-      </div>
-      <div>
-          <input type="text" placeholder="아이디"/>
-      </div>
-      <div>
-          <input type="password" placeholder="비밀번호"/>
-      </div>
-      
-    </div>
-    <div className={styles.login_button}>
-      
-      로그인
-    </div>
-  </div>
+  const handleSignup = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
 
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+    createUserWithEmailAndPassword(auth, String(data.email), String(data.type))
+      .then((userCredential) => {
+        setDoc(doc(db, "users", userCredential.user.uid), {
+          userId: String(data.name),
+        });
+      })
+      .catch((error) => {
+        // TODO: 이메일 형식이 잘못되거나 중복될 경우 사용자 관점에서 명확한 에러 처리
+        console.log(error);
+        alert("회원가입에 실패했습니다. 다시 시도해주세요.");
+      });
+  };
+  return (
+    <div className={styles.login_page}>
+      <h1>Rainit</h1>
+      <form onSubmit={(e) => handleSignup(e)}>
+        <div className={styles.auth_title}>회원가입</div>
+        <input name="name" placeholder="닉네임" required />
+        <input type="email" name="email" placeholder="이메일" required />
+        <input
+          type="password"
+          name="password"
+          placeholder="비밀번호"
+          required
+        />
+        <button className={styles.login_button} type="submit">
+          회원가입
+        </button>
+      </form>
+    </div>
   );
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,10 +3,8 @@
 import { FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import styles from "./page.module.scss";
-import { createUserWithEmailAndPassword } from "firebase/auth";
-import { auth, db } from "../../lib/firebase";
-import { doc, setDoc } from "firebase/firestore";
 import Logo from "../_common/Logo";
+import { signup } from "@/lib/firebase/authAPI";
 
 // TODO: validation 작업. (react-hook-form 라이브러리 추천)
 export default function SignUpPage() {
@@ -21,22 +19,9 @@ export default function SignUpPage() {
       return;
     }
 
-    createUserWithEmailAndPassword(
-      auth,
-      String(data.email),
-      String(data.password)
-    )
-      .then((userCredential) => {
-        setDoc(doc(db, "users", userCredential.user.uid), {
-          userId: String(data.name),
-        });
-        router.push("/login");
-      })
-      .catch((error) => {
-        // TODO: 이메일 형식이 잘못되거나 중복될 경우 사용자 관점에서 명확한 에러 처리
-        console.log(error);
-        alert("회원가입에 실패했습니다. 다시 시도해주세요.");
-      });
+    signup(String(data.email), String(data.password), () =>
+      router.push("/login")
+    );
   };
   return (
     <form onSubmit={(e) => handleSignup(e)} className={styles.main}>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,21 +1,32 @@
 "use client";
 
 import { FormEvent } from "react";
+import { useRouter } from "next/navigation";
 import styles from "./page.module.scss";
 import { createUserWithEmailAndPassword } from "firebase/auth";
 import { auth, db } from "../../lib/firebase";
 import { doc, setDoc } from "firebase/firestore";
+import Logo from "../_common/Logo";
 
-export default function LoginPage() {
+// TODO: validation 작업. (react-hook-form 라이브러리 추천)
+export default function SignUpPage() {
+  const router = useRouter();
+
   const handleSignup = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     const data = Object.fromEntries(new FormData(e.currentTarget));
+    if (data.password !== data.check_password) {
+      alert("비밀번호가 일치하지 않습니다. 다시 시도해주세요.");
+      return;
+    }
+
     createUserWithEmailAndPassword(auth, String(data.email), String(data.type))
       .then((userCredential) => {
         setDoc(doc(db, "users", userCredential.user.uid), {
           userId: String(data.name),
         });
+        router.push("/login");
       })
       .catch((error) => {
         // TODO: 이메일 형식이 잘못되거나 중복될 경우 사용자 관점에서 명확한 에러 처리
@@ -24,22 +35,34 @@ export default function LoginPage() {
       });
   };
   return (
-    <div className={styles.login_page}>
-      <h1>Rainit</h1>
-      <form onSubmit={(e) => handleSignup(e)}>
-        <div className={styles.auth_title}>회원가입</div>
-        <input name="name" placeholder="닉네임" required />
-        <input type="email" name="email" placeholder="이메일" required />
-        <input
-          type="password"
-          name="password"
-          placeholder="비밀번호"
-          required
-        />
-        <button className={styles.login_button} type="submit">
-          회원가입
-        </button>
-      </form>
-    </div>
+    <form onSubmit={(e) => handleSignup(e)} className={styles.main}>
+      <div />
+      <div>
+        <Logo />
+        <div className={styles.inputs}>
+          <input name="name" placeholder="닉네임을 입력하세요" required />
+          <input
+            type="email"
+            name="email"
+            placeholder="이메일을 입력하세요"
+            required
+          />
+          <input
+            type="password"
+            name="password"
+            placeholder="비밀번호를 입력하세요"
+            required
+          />
+          <input
+            type="password"
+            name="check_password"
+            placeholder="비밀번호를 다시 입력하세요"
+          />
+        </div>
+      </div>
+      <button className={styles.button} type="submit">
+        회원가입
+      </button>
+    </form>
   );
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -21,7 +21,11 @@ export default function SignUpPage() {
       return;
     }
 
-    createUserWithEmailAndPassword(auth, String(data.email), String(data.type))
+    createUserWithEmailAndPassword(
+      auth,
+      String(data.email),
+      String(data.password)
+    )
       .then((userCredential) => {
         setDoc(doc(db, "users", userCredential.user.uid), {
           userId: String(data.name),

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -1,5 +1,7 @@
 // src/lib/firebase.js
 import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -12,4 +14,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 
-export default app;
+export const auth = getAuth(app);
+export const db = getFirestore(app); 

--- a/src/lib/firebase/authAPI.ts
+++ b/src/lib/firebase/authAPI.ts
@@ -1,0 +1,88 @@
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from "firebase/auth";
+import { auth, db } from ".";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { useEffect, useState } from "react";
+
+export const login = (email: string, password: string, onSuccess: () => void) => {
+    signInWithEmailAndPassword(auth, String(email), String(password))
+    .then((_) => {
+        onSuccess();
+    })
+    .catch((error) => {
+        // TODO: 사용자에게 명확한 에러 메시지 표시
+        console.log(error);
+        alert("로그인에 실패했습니다. 다시 시도해주세요.");
+    });
+};
+export const signup = (email: string, password: string, onSuccess: () => void) => {
+    createUserWithEmailAndPassword(
+      auth,
+      String(email),
+      String(password)
+    )
+      .then((userCredential) => {
+        setDoc(doc(db, "users", userCredential.user.uid), {
+          userId: String(name),
+        });
+        onSuccess();
+      })
+      .catch((error) => {
+        // TODO: 이메일 형식이 잘못되거나 중복될 경우 사용자 관점에서 명확한 에러 처리
+        console.log(error);
+        alert("회원가입에 실패했습니다. 다시 시도해주세요.");
+      });
+};
+
+export interface UserInfo {
+    email: string;
+    name: string;
+}
+/*
+유저 정보 get
+ex) 
+  const SomeComponent = () => {
+    const { userInfo, isLoading, isError } = useUserInfo();
+    console.log(auth.currentUser);
+
+    if (isLoading) return <div>Loading...</div>;
+    if (isError) return <div>Error occured</div>;
+
+    return <div>{userInfo.name}</div>;
+  }
+*/
+export const useUserInfo = () => {
+    const [userInfo, setUserInfo] = useState<UserInfo>({
+        email: "",
+        name: "",
+    });
+    const [isLoading, setIsLoading] = useState(true);
+    const [isError, setIsError] = useState(false);
+
+    const fetchUserInfo = async () => {
+      const user = auth.currentUser;
+      if(!user || !user.email) return null;
+      const docRef = doc(db, "users", user.uid)    
+
+      const docSnap = await getDoc(docRef)
+      if(docSnap.exists()) {
+        const result: UserInfo = { email: user.email, name: docSnap.data().userId };
+        return result; 
+      } else {
+          // TODO: 사용자 정보가 없으나 회원가입이 완료된 경우
+          return { email: user.email, name: "anonymous" };
+      }
+    }
+
+    useEffect(() => {
+      fetchUserInfo().then((info) => {
+          if(info) {
+              setUserInfo(info);
+          }
+          setIsLoading(false);
+      }).catch((e) => {
+        setIsError(true)
+      });
+    }, [])
+
+    return { userInfo, isLoading, isError };
+}

--- a/src/lib/firebase/index.ts
+++ b/src/lib/firebase/index.ts
@@ -1,4 +1,3 @@
-// src/lib/firebase.js
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->

## 구현/변경 사항
- 회원가입 기능, 페이지 구현
  - validation은 안했습니다. 추후 변경 필요
- 로그인 기능 구현
  - UI 작업 해주실 분 구해요
- 사용자 정보 훅 (useUserInfo)
  - 새로고침하면 사라집니다 세션 사용 필요

## 공유할 내용
- 사용자 정보관련
  - 사용자 정보를 firebase auth와 firestore의 users 컬렉션 두 곳에 저장합니다.
  - firebase auth의 경우 '이메일과 비밀번호'를 사용해서, 로그인과 회원가입 시 이메일도 따로 받아주고 있습니다. 따로 받는 사용자 이름은 users 컬렉션 문서의 userId 필드에 저장합니다.
  - users 컬랙션의 문서ID는 auth의 uid와 같습니다

